### PR TITLE
Changes to handle dependencies and streamline execution

### DIFF
--- a/roastable.py
+++ b/roastable.py
@@ -37,10 +37,12 @@ def spn_lookup(address, dn, password):
 	except ldap3.core.exceptions.LDAPBindError as e:
 		print('LDAP Bind Failed: ', e) 
 
-
-if __name__ == '__main__':
+def main():
 	address = input("server: ")
 	domain = input("domain: ")
 	username = input("username: ")
 	password = getpass.getpass("password: ")
-	spn_lookup(address, "%s\%s" % (domain,username), password)
+	spn_lookup(address, "%s\%s" % (domain, username), password)
+
+if __name__ == '__main__':
+	main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='roastable',
+    version='0.1',
+    py_modules=['roastable'],
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        'ldap3',
+    ],
+    entry_points='''
+        [console_scripts]
+        roastable=roastable:main
+    ''',
+)


### PR DESCRIPTION
Created setup.py with ldap3 as a dep
Moved prompts to a main function so we can call it via console_scripts in setup.py

`pip install -e .` within the roastable working directory will install via setup.py and allow for calling roastable simply with `roastable` while inside the virtualenv.